### PR TITLE
[Release] GitHub Users 1.1 -- pagination added

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "com.goodapps.github_users"
         minSdk 21
         targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/goodapps/github_users/data/models/DetailedUserItemDto.kt
+++ b/app/src/main/java/com/goodapps/github_users/data/models/DetailedUserItemDto.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class DetailedUserItemDto(
     @SerialName("id")
-    val id: Long,
+    val id: Int,
     @SerialName("avatar_url")
     val avatarUrl: String? = null,
     @SerialName("login")

--- a/app/src/main/java/com/goodapps/github_users/data/models/UserItemDto.kt
+++ b/app/src/main/java/com/goodapps/github_users/data/models/UserItemDto.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UserItemDto(
     @SerialName("id")
-    val id: Long,
+    val id: Int,
     @SerialName("avatar_url")
     val avatarUrl: String? = null,
     @SerialName("login")

--- a/app/src/main/java/com/goodapps/github_users/data/repository/users/UsersRepository.kt
+++ b/app/src/main/java/com/goodapps/github_users/data/repository/users/UsersRepository.kt
@@ -6,7 +6,7 @@ import com.goodapps.github_users.data.models.UserItemDto
 
 interface UsersRepository {
 
-    suspend fun getUsers(): List<UserItemDto>
+    suspend fun getUsers(since: Int?, perPage: Int?): List<UserItemDto>
 
     suspend fun getUser(login: String): DetailedUserItemDto
 }

--- a/app/src/main/java/com/goodapps/github_users/data/repository/users/UsersRepositoryImpl.kt
+++ b/app/src/main/java/com/goodapps/github_users/data/repository/users/UsersRepositoryImpl.kt
@@ -15,8 +15,15 @@ class UsersRepositoryImpl @Inject constructor(
     private val httpClient: HttpClient
 ) : UsersRepository {
 
-    override suspend fun getUsers() = withContext(Dispatchers.IO) {
-        httpClient.get("users").body<List<UserItemDto>>()
+    override suspend fun getUsers(since: Int?, perPage: Int?) = withContext(Dispatchers.IO) {
+        httpClient.get("users") {
+            if (since != null) {
+                parameter("since", since.toString())
+            }
+            if (perPage != null) {
+                parameter("per_page", perPage.toString())
+            }
+        }.body<List<UserItemDto>>()
     }
 
     override suspend fun getUser(login: String) = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/goodapps/github_users/domain/interactors/UsersInteractor.kt
+++ b/app/src/main/java/com/goodapps/github_users/domain/interactors/UsersInteractor.kt
@@ -20,21 +20,38 @@ class UsersInteractor @Inject constructor(
     private val _usersListFlow = MutableStateFlow<List<User>>(emptyList())
     val usersListFlow: StateFlow<List<User>>
         get() = _usersListFlow
+    private var since: Int? = null
+    private var perPage: Int? = null
 
     private var token: String? = null
 
-    suspend fun fetchUsers(): Result<List<User>> = withContext(Dispatchers.IO) {
+    suspend fun fetchUsers(loadMore: Boolean = false): Result<List<User>> = withContext(Dispatchers.IO) {
 //        if (token.isNullOrBlank()) {
 //            return@withContext Result.failure(IllegalAccessException("Missed GitHub User token. Please try to sign in again"))
 //        }
-        val result = getUsersUseCase.execute()
+//        val result = getUsersUseCase.execute()
+//        if (result.isSuccess) {
+//            _usersListFlow.tryEmit(result.getOrDefault(emptyList()))
+//        }
+//        result
+        since = if (loadMore) {
+            _usersListFlow.value.lastOrNull()?.id
+        } else {
+            null
+        }
+        val result = getUsersUseCase.execute(since, perPage)
         if (result.isSuccess) {
-            _usersListFlow.tryEmit(result.getOrDefault(emptyList()))
+            val newUsers = result.getOrDefault(emptyList())
+            if (loadMore) {
+                _usersListFlow.tryEmit(_usersListFlow.value + newUsers)
+            } else {
+                _usersListFlow.tryEmit(newUsers)
+            }
         }
         result
     }
 
-    suspend fun getUserOffline(userId: Long) = withContext(Dispatchers.IO) {
+    suspend fun getUserOffline(userId: Int) = withContext(Dispatchers.IO) {
         _usersListFlow.value.firstOrNull { it.id == userId }
     }
 

--- a/app/src/main/java/com/goodapps/github_users/domain/models/User.kt
+++ b/app/src/main/java/com/goodapps/github_users/domain/models/User.kt
@@ -1,7 +1,7 @@
 package com.goodapps.github_users.domain.models
 
 data class User(
-    val id: Long,
+    val id: Int,
     val avatarUrl: String? = null,
     val login: String,
     val name: String? = null,

--- a/app/src/main/java/com/goodapps/github_users/domain/usecases/api/GetUsersUseCase.kt
+++ b/app/src/main/java/com/goodapps/github_users/domain/usecases/api/GetUsersUseCase.kt
@@ -3,5 +3,5 @@ package com.goodapps.github_users.domain.usecases.api
 import com.goodapps.github_users.domain.models.User
 
 interface GetUsersUseCase {
-    suspend fun execute(): Result<List<User>>
+    suspend fun execute(since: Int?, perPage: Int?): Result<List<User>>
 }

--- a/app/src/main/java/com/goodapps/github_users/domain/usecases/impl/GetUsersUseCaseImpl.kt
+++ b/app/src/main/java/com/goodapps/github_users/domain/usecases/impl/GetUsersUseCaseImpl.kt
@@ -12,9 +12,9 @@ class GetUsersUseCaseImpl @Inject constructor(
     private val usersRepository: UsersRepository
 ) : GetUsersUseCase {
 
-    override suspend fun execute(): Result<List<User>> {
+    override suspend fun execute(since: Int?, perPage: Int?): Result<List<User>> {
         return try {
-            val users = usersRepository.getUsers()
+            val users = usersRepository.getUsers(since, perPage)
             Result.success(users.map(UserItemDto::toDomain))
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/goodapps/github_users/ui/models/common/DetailedUserUIModel.kt
+++ b/app/src/main/java/com/goodapps/github_users/ui/models/common/DetailedUserUIModel.kt
@@ -3,7 +3,7 @@ package com.goodapps.github_users.ui.models.common
 import com.goodapps.github_users.domain.models.User
 
 data class DetailedUserUIModel(
-    val id: Long,
+    val id: Int,
     val avatarUrl: String?,
     val login: String,
     val name: String? = null,

--- a/app/src/main/java/com/goodapps/github_users/ui/models/common/UserUIModel.kt
+++ b/app/src/main/java/com/goodapps/github_users/ui/models/common/UserUIModel.kt
@@ -3,7 +3,7 @@ package com.goodapps.github_users.ui.models.common
 import com.goodapps.github_users.domain.models.User
 
 data class UserUIModel(
-    val id: Long,
+    val id: Int,
     val avatarUrl: String?,
     val login: String
 )

--- a/app/src/main/java/com/goodapps/github_users/ui/screens/UsersScreen.kt
+++ b/app/src/main/java/com/goodapps/github_users/ui/screens/UsersScreen.kt
@@ -3,22 +3,29 @@ package com.goodapps.github_users.ui.screens
 import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -43,52 +50,77 @@ fun UsersScreen(onNavigateToDetail: (String) -> Unit) {
     val viewModel: UsersViewModel = hiltViewModel()
     val screenModel = viewModel.screenModel.collectAsState()
 
-    if (screenModel.value.showProgress) {
+    if (screenModel.value.showProgress && screenModel.value.users.isEmpty()) {
         LoadingIndicator()
     } else {
         val users = screenModel.value.users
         if (users.isNotEmpty()) {
-            UsersList(users = screenModel.value.users) {
-                onNavigateToDetail(it.login)
-            }
-        } else {
-            EmptyView()
+            UsersList(
+                users = users,
+                onItemClick = { onNavigateToDetail(it.login) },
+                onLoadMore = {
+                    val visibleItemCount = 30
+                    val lastVisibleItemPosition = users.size - 1
+                    val totalItemCount = screenModel.value.users.size
+                    viewModel.loadMoreData(
+                        visibleItemCount,
+                        lastVisibleItemPosition,
+                        totalItemCount
+                    )
+                }
+            )
         }
     }
 
-    LaunchedEffect(key1 = screenModel.value.errorEvent) {
-        screenModel.value.errorEvent?.getContentIfNotHandled()?.let(context::showToast)
+    if (screenModel.value.errorEvent != null) {
+        LaunchedEffect(key1 = screenModel.value.errorEvent) {
+            screenModel.value.errorEvent?.getContentIfNotHandled()?.let(context::showToast)
+        }
     }
 }
 
 @Composable
-fun UsersList(users: List<UserUIModel>, onItemClick: (UserUIModel) -> Unit) {
-    LazyColumn {
-        itemsIndexed(users) { index, item ->
-            UserItem(user = item, onItemClick = onItemClick)
-            if (index < users.size - 1) {
-                Spacer(modifier = Modifier.height(7.5.dp))
-                Divider(
-                    modifier = Modifier
-                        .height(1.dp)
-                        .padding(horizontal = 16.dp)
-                        .alpha(0.5f),
-                    color = Color.LightGray
-                )
-                Spacer(modifier = Modifier.height(3.5.dp))
-            } else {
-                Spacer(modifier = Modifier.height(3.5.dp))
+fun UsersList(
+    users: List<UserUIModel>,
+    onItemClick: (UserUIModel) -> Unit,
+    onLoadMore: () -> Unit
+) {
+    val state = rememberLazyListState()
+    val itemCount = state.layoutInfo.totalItemsCount
+    val loadingMore = state.layoutInfo.visibleItemsInfo.lastOrNull()?.index == itemCount - 1
+    if (loadingMore) {
+        onLoadMore()
+    }
+    LazyColumn(
+        state = state,
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        content = {
+            itemsIndexed(users) { index, item ->
+                UserItem(user = item, onItemClick = onItemClick)
+                if (index < users.size - 1) {
+                    Spacer(Modifier.height(8.dp))
+                    Divider(
+                        modifier = Modifier
+                            .height(1.dp)
+                            .alpha(0.5f),
+                        color = Color.LightGray
+                    )
+                }
             }
         }
-    }
+    )
 }
+
 
 @Composable
 fun UserItem(user: UserUIModel, onItemClick: (UserUIModel) -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp)
+            .padding(vertical = 8.dp)
             .clickable {
                 onItemClick.invoke(user)
             }


### PR DESCRIPTION
[Feature] Add pagination to UsersScreen

This pull request adds pagination to the `UsersScreen` feature in GitHub Users 1.1 to improve performance and user experience when loading a large number of users. Pagination is implemented using a `LazyColumn` and `rememberLazyListState()` to handle scrolling and loading of additional items. 